### PR TITLE
change suite.rc cycling option name to cycling mode

### DIFF
--- a/dev/suites/integer/one/suite.rc
+++ b/dev/suites/integer/one/suite.rc
@@ -3,7 +3,7 @@
     initial cycle time = 1
     final cycle time = 16
     runahead factor = 4 
-    cycling = integer
+    cycling mode = integer
     [[special tasks]]
         sequential = seq
     [[dependencies]]

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -167,7 +167,7 @@ SPEC = {
     'scheduling' : {
         'initial cycle time'                  : vdr(vtype='cycletime'),
         'final cycle time'                    : vdr(vtype='cycletime'),
-        'cycling'                             : vdr(vtype='string', default="gregorian", options=["360","gregorian","integer"] ),
+        'cycling mode'                             : vdr(vtype='string', default="gregorian", options=["360","gregorian","integer"] ),
         'runahead factor'                     : vdr(vtype='integer', default=2 ),
         'queues' : {
             'default' : {

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -143,7 +143,7 @@ class config( object ):
                 write_proc=write_proc )
         self.cfg = self.pcfg.get(sparse=True)
 
-        if 'cycling' not in self.cfg['scheduling']:
+        if 'cycling mode' not in self.cfg['scheduling']:
             # Auto-detect integer cycling for pure async graph suites.
             dependency_map = self.cfg.get('scheduling', {}).get(
                 'dependencies', {})
@@ -156,7 +156,9 @@ class config( object ):
                         break
                 else:
                     # There aren't any other graphs, so set integer cycling.
-                    self.cfg['scheduling']['cycling'] = INTEGER_CYCLING_TYPE
+                    self.cfg['scheduling']['cycling mode'] = (
+                        INTEGER_CYCLING_TYPE
+                    )
                     if 'initial cycle time' not in self.cfg['scheduling']:
                         self.cfg['scheduling']['initial cycle time'] = "1"
                     if 'final cycle time' not in self.cfg['scheduling']:

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -469,7 +469,7 @@ def init_from_cfg(cfg):
     initial_cycle_time = cfg['scheduling']['initial cycle time']
     final_cycle_time = cfg['scheduling']['final cycle time']
     assume_utc = cfg['cylc']['UTC mode']
-    cycling_mode = cfg['scheduling']['cycling']
+    cycling_mode = cfg['scheduling']['cycling mode']
     test_cycle_time = initial_cycle_time
     if initial_cycle_time is None:
         test_cycle_time = final_cycle_time

--- a/lib/cylc/cycling/loader.py
+++ b/lib/cylc/cycling/loader.py
@@ -93,7 +93,7 @@ def get_sequence_cls(cycling_type=None):
 
 
 def init_cyclers(cfg):
-    DefaultCycler.TYPE = cfg['scheduling']['cycling']
+    DefaultCycler.TYPE = cfg['scheduling']['cycling mode']
     if DefaultCycler.TYPE in ['360','gregorian']:
         DefaultCycler.TYPE = ISO8601_CYCLING_TYPE
     for cycling_type, init_func in INIT_FUNCTIONS.items():

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -692,7 +692,7 @@ class scheduler(object):
         flags.utc = self.config.cfg['cylc']['UTC mode']
 
         # Capture cycling mode
-        flags.cycling_mode = self.config.cfg['scheduling']['cycling']
+        flags.cycling_mode = self.config.cfg['scheduling']['cycling mode']
 
         if not reconfigure:
             slog = suite_log( self.suite )

--- a/tests/cyclers/360/suite.rc
+++ b/tests/cyclers/360/suite.rc
@@ -6,7 +6,7 @@
 [scheduling]
     initial cycle time = 20130228T00
     final cycle time = 20130301T00
-    cycling = 360
+    cycling mode = 360
     [[dependencies]]
         [[[ P1D ]]]
             graph = foo[-P1D] => foo

--- a/tests/cyclers/integer1/suite.rc
+++ b/tests/cyclers/integer1/suite.rc
@@ -5,7 +5,7 @@
     initial cycle time = 1
     final cycle time = 16
     runahead factor = 4 
-    cycling = integer
+    cycling mode = integer
     [[special tasks]]
         sequential = seq
     [[dependencies]]


### PR DESCRIPTION
This renames the new suite.rc input `cycling` to `cycling mode`.

This is an incomplete change, as the documentation still needs
changing.
